### PR TITLE
Packit onboard w copr

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -8,8 +8,12 @@ downstream_package_name: python-pulsectl
 # Upstream currently set to fork
 upstream_project_url: https://github.com/stickster/python-pulse-control
 
-create_tarball_command: ["python3", "setup.py", "sdist", "--dist-dir", "."]
-current_version_command: ["python3", "setup.py", "--version"]
+actions:
+  create-archive:
+  - "python3 setup.py sdist --dist-dir ."
+  - "sh -c 'echo pulsectl-$(python3 setup.py --version).tar.gz'"
+  get-current-version:
+  - "python3 setup.py --version"
 
 jobs:
 - job: sync_from_downstream

--- a/packit.yaml
+++ b/packit.yaml
@@ -3,7 +3,7 @@
 # docs: https://github.com/packit-service/packit/blob/master/docs/configuration.md
 specfile_path: python-pulsectl.spec
 
-upstream_package_name: python-pulse-control
+upstream_package_name: pulsectl
 downstream_package_name: python-pulsectl
 # Upstream currently set to fork
 upstream_project_url: https://github.com/stickster/python-pulse-control


### PR DESCRIPTION
The documentation is outdated, sorry about that

Actions are preferred and more powerful now - https://packit.dev/docs/actions/.
The upstream name in this case is the name of python package.
It should work after these changes - Example: https://github.com/dhodovsk/python-pulse-control/pull/1.